### PR TITLE
update color scheme: change areas of focus

### DIFF
--- a/mapping.py
+++ b/mapping.py
@@ -107,8 +107,8 @@ def analyze():
 def map(properties):
     properties['amenity_count'] = properties['amenity_count'].astype('int')
     fig = px.choropleth_mapbox(properties, geojson=properties.geometry, locations=properties.index, color='amenity_count',
-                                color_continuous_scale="Viridis_r",
-                                mapbox_style="carto-positron",
+                                color_continuous_scale="cividis",
+                                mapbox_style="carto-darkmatter",
                                 
                                 zoom=12, center = {"lat":  48.431699, "lon": -123.319873},
                                 opacity=.5,


### PR DESCRIPTION
From Bridget:

> Something we were thinking about with the colour scheme is to have the most well served areas (i.e. approximately the top quartile for the amenity count) visually pop, so that those regions would look like hot spots on the map. We also wanted the least well served areas to fall away visually, and start to blend with the background. We tried to find a colour scale that set to background to low intensity (black), with a scale that went from high vibrancy high contrast at the most amenity-dense end to low vibrancy low contrast at the other end of the scale.
> 
> I think the main thing I'm not super happy about with this colour palette is that it's not the most visually appealing (i.e. "pretty") combination of colours. What I like is that it helps make the most desirable areas stand out strongly, both relative to the background and relative to moderate-low amenity served areas. Vibrant yellow has visual prominence that helps make it stand out relative to the blue-grays and black background. 

![image](https://user-images.githubusercontent.com/969644/233741109-b22b529c-58d2-4725-87ae-2a29b11ce7b1.png)
